### PR TITLE
Update to Dart 2.17 and fix some lints/warnings

### DIFF
--- a/built_site/analysis_options.yaml
+++ b/built_site/analysis_options.yaml
@@ -2,11 +2,12 @@ include: package:lints/recommended.yaml
 
 analyzer:
   exclude: ["**.g.dart"]
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:
-    avoid_returning_null: false # We have proper null-safety now
-    invariant_booleans: false # this is just completely broken
-    literal_only_boolean_expressions: false # sometimes a while (true) is just more convenient
     prefer_void_to_null: false # I know what I'm doing, might want to turn this back on after migrating to null safety
     no_default_cases: false # I just happen to disagree with this.

--- a/built_site/lib/src/config.dart
+++ b/built_site/lib/src/config.dart
@@ -67,7 +67,7 @@ Object? _merge(Object? parent, Object? override) {
     final keys = parent.keys.cast<Object?>().followedBy(override.keys).toSet();
 
     return <String, Object?>{
-      for (final key in keys) "$key": _merge(parent[key], override[key]),
+      for (final key in keys) '$key': _merge(parent[key], override[key]),
     };
   }
 

--- a/built_site/lib/src/markdown/dart_highlight.dart
+++ b/built_site/lib/src/markdown/dart_highlight.dart
@@ -204,12 +204,12 @@ class _HighlightingVisitor extends RecursiveAstVisitor<void> {
   void visitClassDeclaration(ClassDeclaration node) {
     _keywordLeaf(node.classKeyword);
     _keywordLeaf(node.abstractKeyword);
-    _visitChildrenWithTitle(node, node.name2);
+    _visitChildrenWithTitle(node, node.name);
   }
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
-    _functionNameLeaf(node.name2);
+    _functionNameLeaf(node.name);
     _typeNameLeaf(node.returnType);
 
     for (final child in node.childNodes) {
@@ -272,7 +272,7 @@ class _HighlightingVisitor extends RecursiveAstVisitor<void> {
     _keywordLeaf(node.extensionKeyword);
     _keywordLeaf(node.onKeyword);
 
-    _visitChildrenWithTitle(node, node.name2);
+    _visitChildrenWithTitle(node, node.name);
   }
 
   @override

--- a/built_site/lib/src/markdown/highlight.dart
+++ b/built_site/lib/src/markdown/highlight.dart
@@ -46,7 +46,7 @@ class _HighlightToMarkdown {
       final prefix = node.noPrefix ? '' : 'hljs-';
       final element = md.Element.withTag('span');
       element.children!.addAll(nodes);
-      element.attributes['class'] = prefix + className!;
+      element.attributes['class'] = prefix + className;
 
       nodes = safedNodes..add(element);
     } else {

--- a/built_site/pubspec.yaml
+++ b/built_site/pubspec.yaml
@@ -4,15 +4,15 @@ version: 0.2.12
 # homepage: https://www.example.com
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: '^5.0.0'
+  analyzer: ^5.2.0
   build: ^2.0.0
   charcode: ^1.2.0
   checked_yaml: ^2.0.1
   crypto: ^3.0.0
-  glob: '^2.0.0'
+  glob: ^2.0.0
   highlight: ^0.7.0
   html: ^0.15.0
   intl: ^0.17.0


### PR DESCRIPTION
The removed lint ignores aren't present in `package:lints` so no need to include them.