### PR TITLE
Generate API docs links for top-level function elements

### DIFF
--- a/extras/code_snippets/lib/src/highlight/dart/dartdoc.dart
+++ b/extras/code_snippets/lib/src/highlight/dart/dartdoc.dart
@@ -55,6 +55,8 @@ Uri documentationForElement(
       reversePath.add('${element.name}.html');
     } else if (element is TypeAliasElement) {
       reversePath.add('${element.name}.html');
+    } else if (element is FunctionElement) {
+      reversePath.add('${element.name}.html');
     } else if (element is ConstructorElement) {
       var constructorName = element.enclosingElement3.name;
       if (element.name.isNotEmpty) {


### PR DESCRIPTION
I am using the index and snippet code in a weird setup, so maybe I did something wrong, but links for top-level functions were linking to just the library. So maybe this isn't the right change or isn't necessary, but it seemed to fix it for me. 